### PR TITLE
add show_mut

### DIFF
--- a/egui-nav/src/lib.rs
+++ b/egui-nav/src/lib.rs
@@ -228,6 +228,23 @@ impl<T: Clone> Nav<T> {
         F: Fn(&mut egui::Ui, &Nav<T>) -> R,
         T: Display + Clone,
     {
+        let mut show_route = show_route;
+        self.show_internal(ui, &mut show_route)
+    }
+
+    pub fn show_mut<F, R>(&self, ui: &mut egui::Ui, mut show_route: F) -> NavResponse<R>
+    where
+        F: FnMut(&mut egui::Ui, &Nav<T>) -> R,
+        T: Display + Clone,
+    {
+        self.show_internal(ui, &mut show_route)
+    }
+
+    fn show_internal<F, R>(&self, ui: &mut egui::Ui, show_route: &mut F) -> NavResponse<R>
+    where
+        F: FnMut(&mut egui::Ui, &Nav<T>) -> R,
+        T: Display + Clone,
+    {
         let id = ui.id().with("nav");
         let mut state = State::load(ui.ctx(), id).unwrap_or_default();
 


### PR DESCRIPTION
we should have an impl that can accept a `FnMut` instead of just `Fn`.

Here is a sample use case:
```
pub fn show(ui: &mut Ui, app: &mut Damus) {
    let routes = app.account_management_view_state.get_routes();

    let nav_response =
        Nav::new(routes)
            .title(false)
            .navigating(false)
            .show_mut(ui, |ui, nav| match nav.top() {
                ManageAccountRoute::AccountManagement => {
                    AccountManagementView::ui(
                        ui,
                        &app.account_manager,
                        &app.ndb,
                        &mut app.img_cache,
                    )
                    .inner
                    .map(ManageAcountRouteResponse::AccountManagement)
                }
                ManageAccountRoute::AddAccount => AccountLoginView::new(&mut app.login_state)
                    .ui(ui)
                    .inner
                    .map(ManageAcountRouteResponse::AddAccount),
            });
       ...
 }
  
 ```
 
 notice how I can pass the references to `AccountManager` and `Ndb` and also pass the mutable reference to `ImgCache`. without this `show_mut` impl I would need to pass the whole `Damus` struct, which works but it isn't ideal