### PR TITLE
fix: match widget ID to layer during transitions

### DIFF
--- a/egui-nav/src/drawer.rs
+++ b/egui-nav/src/drawer.rs
@@ -192,7 +192,7 @@ impl<'a, Route: Clone> NavDrawer<'a, Route> {
         let offset = state.offset;
 
         if let Some(action) = state.action {
-            action.handle(ui, &mut state, DragDirection::LeftToRight, max, rest);
+            action.handle(ui, &mut state, DragDirection::LeftToRight, max, rest, true);
         }
 
         if state.offset == rest {

--- a/egui-nav/src/lib.rs
+++ b/egui-nav/src/lib.rs
@@ -325,20 +325,24 @@ impl<'a, Route: Clone> Nav<'a, Route> {
                 ),
             );
 
-            let layer_id = if transitioning {
+            let (layer_id, fg_id) = if transitioning {
                 // when transitioning, we need a new layer id otherwise the
                 // view transform will transform more things than we want
-                LayerId::new(Order::Foreground, ui.id().with("fg"))
+                // We also need a distinct widget ID to match the layer change
+                (
+                    LayerId::new(Order::Foreground, ui.id().with("fg")),
+                    ui.id().with("fg"),
+                )
             } else {
                 // if we don't use the same layer id as the ui, then we
                 // will have scrollview MouseWheel scroll issues due to
                 // the way rect_contains_pointer works with overlapping
                 // layers
-                ui.layer_id()
+                (ui.layer_id(), ui.id())
             };
             let response = render_fg(
                 ui,
-                ui.id(), // this must be ui.id() to not break scroll positions
+                fg_id,
                 layer_id,
                 Some(Vec2::new(state.offset, 0.0)),
                 clip,

--- a/egui-nav/src/popup_sheet.rs
+++ b/egui-nav/src/popup_sheet.rs
@@ -168,6 +168,7 @@ impl<'a, Route: Clone> PopupSheet<'a, Route> {
                 crate::DragDirection::Vertical,
                 max_height,
                 max_size,
+                true,
             );
         }
 


### PR DESCRIPTION
Prevents "Widget changed layer_id during frame" panic by ensuring widget IDs are unique per layer. When transitioning to Foreground layer, use ui.id().with("fg") instead of reusing ui.id() from Background layer.